### PR TITLE
Add library category

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Peter Lerup
 maintainer=Peter Lerup <peter@lerup.com>
 sentence=Implementation of the Arduino software serial for ESP8266.
 paragraph=
+category=Signal Input/Output
 url=
 architectures=esp8266


### PR DESCRIPTION
Since Arduino 1.5.6, the category library metadata is implemented (see https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format).

Making the libraries 1.5 compliant removes the warnings generated for those of us who are using arduino-builder (e.g. `WARNING: Category '' in library SoftwareSerial is not valid. Setting to 'Uncategorized'`).