### PR TITLE
attachInterrupt() support and interrupt-driven rx

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is not possible to use the standard Arduino attachInterrupt when using this l
 
 ## Capability / Limitations
 
-1. full duplex (loop-back) up to 57600 (latency of interrupt by attachInterrupt() on ESP8266 is SUPER HIGH, approx 300 cycles @ 80Mhz, i dunno why...)
+1. full duplex (loop-back) up to 115200 (latency of interrupt by attachInterrupt() on ESP8266 is SUPER HIGH, approx 300 cycles @ 80Mhz, i dunno why...)
 2. half duplex up to 115200 (thx to the high latency, i can't achieve higher baudrate even with a 80Mhz mcu...)
 3. transmit to one endpoint at a time (due to the nature of no tx buffering)
 4. receive from all endpoints, always (thx to interrupt), but you may encounter data-drop at high baudrate. use a lower baudrate if more than 1 SoftwareSerial is used.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ timings. This may lead to bit errors when having heavy data traffic in high baud
 
 It is not possible to use the standard Arduino attachInterrupt when using this library.
 
+## Capability / Limitations
+
+1. full duplex (loop-back) up to 57600 (latency of interrupt by attachInterrupt() on ESP8266 is SUPER HIGH, approx 300 cycles @ 80Mhz, i dunno why...)
+2. half duplex up to 115200 (thx to the high latency, i can't achieve higher baudrate even with a 80Mhz mcu...)
+3. transmit to one endpoint at a time (due to the nature of no tx buffering)
+4. receive from all endpoints, always (thx to interrupt), but you may encounter data-drop at high baudrate. use a lower baudrate if more than 1 SoftwareSerial is used.
+
+# Issues
+
+1. the first transmit will always have timing problem, another mystery......

--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -30,7 +30,7 @@ SoftwareSerial::SoftwareSerial(int receivePin, int transmitPin, bool inverse_log
   // the rxPin has to be on an interrupt, and isr != NULL for rx to work.
   m_rxPin(receivePin),
   m_rxInterrupt(digitalPinToInterrupt(receivePin)),
-  m_rxValid(true),
+  m_rxValid(false),
   // txPin can be any GPIO pin (I guess...)
   m_txValid(transmitPin < NUM_DIGITAL_PINS), m_txPin(transmitPin),
   // other stuff

--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -158,7 +158,7 @@ int SoftwareSerial::available() {
 
 #define WAIT { while (ESP.getCycleCount() - start < wait); wait += m_bitTime; }
 
-size_t SoftwareSerial::write(uint8_t b) {
+size_t ICACHE_RAM_ATTR SoftwareSerial::write(uint8_t b) {
   if (!m_txValid)
     return 0;
 
@@ -190,7 +190,7 @@ size_t SoftwareSerial::write(uint8_t b) {
   return 1;
 }
 
-void SoftwareSerial::updateFrame(uint8_t bitState, unsigned long const endTime)
+void ICACHE_RAM_ATTR SoftwareSerial::updateFrame(uint8_t bitState, unsigned long const endTime)
 {
   for (uint32_t i = m_lastBitTime; i < endTime - m_bitTime / 2; i += m_bitTime)
   {
@@ -203,7 +203,7 @@ void SoftwareSerial::updateFrame(uint8_t bitState, unsigned long const endTime)
   m_lastBitTime = endTime;
 }
 
-void SoftwareSerial::commitFrame() {
+void ICACHE_RAM_ATTR SoftwareSerial::commitFrame() {
   if (m_frameCommitted)
     return;
 
@@ -226,7 +226,7 @@ void SoftwareSerial::commitFrame() {
   }
 }
 
-void SoftwareSerial::rxRead() {
+void ICACHE_RAM_ATTR SoftwareSerial::rxRead() {
   uint32_t now = ESP.getCycleCount();
 
   if (now - m_lastBitTime > m_bitTime * (1 + 8 + 1)) {
@@ -237,4 +237,12 @@ void SoftwareSerial::rxRead() {
   }
 
   updateFrame(digitalRead(m_rxPin), now);
+}
+
+template <uint8_t interrupt>
+void ICACHE_RAM_ATTR SoftwareSerial::M_isr()
+{
+  register SoftwareSerial *thiz = M_instances[interrupt];
+  if (thiz != NULL)
+    thiz->rxRead();
 }

--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -110,13 +110,11 @@ void SoftwareSerial::attachRxInterrupt() {
 }
 
 void SoftwareSerial::detachRxInterrupt() {
-  if (m_rxValid) {
-    // do not attempt to detach interrupt not handled by this
-    if (M_instances[m_rxInterrupt] == this)
-    {
-      M_instances[m_rxInterrupt] = NULL;
-      detachInterrupt(m_rxInterrupt);
-    }
+  // do not attempt to detach interrupt not handled by this
+  if (M_instances[m_rxInterrupt] == this)
+  {
+    M_instances[m_rxInterrupt] = NULL;
+    detachInterrupt(m_rxInterrupt);
   }
 }
 

--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -160,7 +160,8 @@ size_t ICACHE_RAM_ATTR SoftwareSerial::write(uint8_t b) {
   digitalWrite(m_txPin, HIGH);
   unsigned long start = ESP.getCycleCount();
   // Start bit;
-  digitalWrite(m_txPin, LOW); WAIT;
+  digitalWrite(m_txPin, LOW);
+  WAIT;
   // data bits
   for (int i = 1;i < 9;++i) {
     digitalWrite(m_txPin, b & 1);

--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -210,15 +210,19 @@ void ICACHE_RAM_ATTR SoftwareSerial::commitFrame(uint32_t now) {
 void ICACHE_RAM_ATTR SoftwareSerial::rxRead() {
   // record this as soon as we enter the interrupt.
   uint32_t now = ESP.getCycleCount();
+  uint8_t state = digitalRead(m_rxPin);
 
   if (now - m_frameStart > m_bitTime * (1 + 8 + 1)) {
     commitFrame(m_frameStart + m_bitTime * (1 + 8 + 1));
-    m_frameCommitted = false;
     m_frameStart = now;
     m_lastBit = 0;
+	
+	// filter out bogus inputs
+	if (state == (m_invert ? HIGH : LOW))
+		m_frameCommitted = false;
   }
 
-  updateFrame(digitalRead(m_rxPin), now);
+  updateFrame(state, now);
 }
 
 template <uint8_t interrupt>

--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -1,187 +1,240 @@
 /*
+/*
 
-SoftwareSerial.cpp - Implementation of the Arduino software serial for ESP8266.
-Copyright (c) 2015 Peter Lerup. All rights reserved.
+  SoftwareSerial.cpp - Implementation of the Arduino software serial for ESP8266.
+  Copyright (c) 2015 Peter Lerup. All rights reserved.
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 
 #include <Arduino.h>
 
-// The Arduino standard GPIO routines are not enough,
-// must use some from the Espressif SDK as well
-extern "C" {
-#include "gpio.h"
-}
-
 #include <SoftwareSerial.h>
 
-#define MAX_PIN 15
+SoftwareSerial * SoftwareSerial::M_instances[EXTERNAL_NUM_INTERRUPTS] = { NULL };
 
-// List of SoftSerial object for each possible Rx pin
-SoftwareSerial *InterruptList[MAX_PIN+1];
-bool InterruptsEnabled = false;
-
-SoftwareSerial::SoftwareSerial(int receivePin, int transmitPin, bool inverse_logic, unsigned int buffSize) {
-   m_rxValid = m_txValid = false;
-   m_buffer = NULL;
-   m_invert = inverse_logic;
-   if (isValidGPIOpin(receivePin)) {
-      m_rxPin = receivePin;
-      m_buffSize = buffSize;
-      m_buffer = (uint8_t*)malloc(m_buffSize);
-      if (m_buffer != NULL) {
-         m_rxValid = true;
-         m_inPos = m_outPos = 0;
-         pinMode(m_rxPin, INPUT);
-         if (!InterruptsEnabled) {
-            ETS_GPIO_INTR_ATTACH(handle_interrupt, 0);
-            InterruptsEnabled = true;
-         }
-         InterruptList[m_rxPin] = this;
-         GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, BIT(m_rxPin));
-         enableRx(true);
-      }
-   }
-   if (isValidGPIOpin(transmitPin)) {
-      m_txValid = true;
-      m_txPin = transmitPin;
-      pinMode(m_txPin, OUTPUT);
-      digitalWrite(m_txPin, !m_invert);
-   }
-   // Default speed
-   begin(9600);
+SoftwareSerial::SoftwareSerial(int receivePin, int transmitPin, bool inverse_logic, unsigned int buffSize):
+  // the rxPin has to be on an interrupt, and isr != NULL for rx to work.
+  m_rxPin(receivePin),
+  m_rxInterrupt(digitalPinToInterrupt(receivePin)),
+  m_rxValid(digitalPinToInterrupt(receivePin) != NOT_AN_INTERRUPT),
+  // txPin can be any GPIO pin (I guess...)
+  m_txValid(transmitPin < NUM_DIGITAL_PINS), m_txPin(transmitPin),
+  // other stuff
+  m_invert(inverse_logic), m_buffSize(buffSize),
+  m_buffer(m_buffer = (uint8_t*)malloc(buffSize)), m_inPos(0), m_outPos(0)
+{
+  if (m_buffer == NULL)
+    m_rxValid = false;
 }
 
 SoftwareSerial::~SoftwareSerial() {
-   enableRx(false);
-   if (m_rxValid)
-      InterruptList[m_rxPin] = NULL;
-   if (m_buffer)
-      free(m_buffer);
-}
-
-bool SoftwareSerial::isValidGPIOpin(int pin) {
-   // Some GPIO pins are reserved by the system
-   return (pin >= 0 && pin <= 5) || (pin >= 12 && pin <= MAX_PIN);
+  detachRxInterrupt();
+  if (m_buffer)
+    free(m_buffer);
 }
 
 void SoftwareSerial::begin(long speed) {
-   // Use getCycleCount() loop to get as exact timing as possible
-   m_bitTime = ESP.getCpuFreqMHz()*1000000/speed;
+  // Use getCycleCount() loop to get as exact timing as possible
+  m_bitTime = ESP.getCpuFreqMHz() * 1000000.0 / speed;
+  m_frameCommitted = true;
+  m_bitState = !m_invert;
+
+  #ifdef SOFTWARESERIAL_DEBUG
+  Serial.print("SoftwareSerial::begin(");
+  Serial.print(speed);
+  Serial.print("), bitTime = ");
+  Serial.print(m_bitTime);
+  #endif
+
+  if (m_rxValid)
+  {
+    pinMode(m_rxPin, INPUT);
+	#ifdef SOFTWARESERIAL_DEBUG
+	Serial.print(", RX");
+	#endif
+  }
+
+  if (m_txValid) {
+    pinMode(m_txPin, OUTPUT);
+    digitalWrite(m_txPin, !m_invert);
+	#ifdef SOFTWARESERIAL_DEBUG
+	Serial.print(", TX");
+	#endif
+  }
+  
+  #ifdef SOFTWARESERIAL_DEBUG
+  Serial.println();
+  #endif
+
+  attachRxInterrupt();
 }
 
-void SoftwareSerial::enableRx(bool on) {
-   if (m_rxValid) {
-      GPIO_INT_TYPE type;
-      if (!on)
-         type = GPIO_PIN_INTR_DISABLE;
-      else if (m_invert)
-         type = GPIO_PIN_INTR_POSEDGE;
-      else
-         type = GPIO_PIN_INTR_NEGEDGE;
-      gpio_pin_intr_state_set(GPIO_ID_PIN(m_rxPin), type);
-   }
+void SoftwareSerial::attachRxInterrupt() {
+  if (m_rxValid) {
+    // do not attempt to attach the interrupt if
+    // the interrupt is currently used bo another instance
+    if (M_instances[m_rxInterrupt] != NULL)
+      return;
+
+    M_instances[m_rxInterrupt] = this;
+
+    // sorry for the switch-case, there's no other way of doing this...
+    void (*isr)() = NULL;
+    switch (m_rxInterrupt) {
+      case 0: isr = M_isr<0>; break;
+      case 1: isr = M_isr<1>; break;
+      case 2: isr = M_isr<2>; break;
+      case 3: isr = M_isr<3>; break;
+      case 4: isr = M_isr<4>; break;
+      case 5: isr = M_isr<5>; break;
+      case 6: isr = M_isr<6>; break;
+      case 7: isr = M_isr<7>; break;
+      case 8: isr = M_isr<8>; break;
+      case 9: isr = M_isr<9>; break;
+      case 10: isr = M_isr<10>; break;
+      case 11: isr = M_isr<11>; break;
+      case 12: isr = M_isr<12>; break;
+      case 13: isr = M_isr<13>; break;
+      case 14: isr = M_isr<14>; break;
+      case 15: isr = M_isr<15>; break;
+      case 16: isr = M_isr<16>; break;
+    }
+
+    // using CHANGE for rx without blocking the CPU
+    attachInterrupt(m_rxInterrupt, isr, CHANGE);
+  }
+}
+
+void SoftwareSerial::detachRxInterrupt() {
+  if (m_rxValid) {
+    // do not attempt to detach interrupt not handled by this
+    if (M_instances[m_rxInterrupt] == this)
+    {
+      M_instances[m_rxInterrupt] = NULL;
+      detachInterrupt(m_rxInterrupt);
+    }
+  }
 }
 
 int SoftwareSerial::read() {
-   if (!m_rxValid || (m_inPos == m_outPos)) return -1;
-   uint8_t ch = m_buffer[m_outPos];
-   m_outPos = (m_outPos+1) % m_buffSize;
-   return ch;
+  if (!m_rxValid || (m_inPos == m_outPos))
+    return -1;
+
+  uint8_t ch = m_buffer[m_outPos];
+  ++m_outPos;
+  m_outPos %= m_buffSize;
+
+  return ch;
 }
 
 int SoftwareSerial::available() {
-   if (!m_rxValid) return 0;
-   int avail = m_inPos - m_outPos;
-   if (avail < 0) avail += m_buffSize;
-   return avail;
+  if (!m_rxValid)
+    return 0;
+
+  // check if we have to commit the frame or not
+  unsigned long now = ESP.getCycleCount();
+  if (now - m_frameStart > m_bitTime * (1 + 8 + 1))
+    commitFrame();
+
+  int avail = m_inPos - m_outPos;
+  if (avail < 0)
+    avail += m_buffSize;
+  return avail;
 }
 
-#define WAIT { while (ESP.getCycleCount()-start < wait); wait += m_bitTime; }
+#define WAIT { while (ESP.getCycleCount() - start < wait); wait += m_bitTime; }
 
 size_t SoftwareSerial::write(uint8_t b) {
-   if (!m_txValid) return 0;
+  if (!m_txValid)
+    return 0;
 
-   if (m_invert) b = ~b;
-   // Disable interrupts in order to get a clean transmit
-   cli();
-   unsigned long wait = m_bitTime;
-   digitalWrite(m_txPin, HIGH);
-   unsigned long start = ESP.getCycleCount();
-    // Start bit;
-   digitalWrite(m_txPin, LOW);
-   WAIT;
-   for (int i = 0; i < 8; i++) {
-     digitalWrite(m_txPin, (b & 1) ? HIGH : LOW);
-     WAIT;
-     b >>= 1;
-   }
-   // Stop bit
-   digitalWrite(m_txPin, HIGH);
-   WAIT;
-   sei();
-   return 1;
+  if (m_invert)
+    b = ~b;
+
+  uint32_t wait = m_bitTime;
+  
+  // Disable interrupts in order to get a clean transmit
+  //uint32_t savedPS = xt_rsil(0);
+
+  digitalWrite(m_txPin, HIGH);
+  unsigned long start = ESP.getCycleCount();
+  // Start bit;
+  digitalWrite(m_txPin, LOW); WAIT;
+  // data bits
+  for (int i = 1;i < 9;++i) {
+    digitalWrite(m_txPin, b & 1);
+	WAIT;
+	b >>= 1;
+  }
+  // Stop bit
+  digitalWrite(m_txPin, HIGH);
+  WAIT;
+
+  // restore interrupt
+  //xt_wsr_ps(savedPS);
+
+  return 1;
 }
 
-void SoftwareSerial::flush() {
-   m_inPos = m_outPos = 0;
+void SoftwareSerial::updateFrame(uint8_t bitState, unsigned long const endTime)
+{
+  for (uint32_t i = m_lastBitTime; i < endTime - m_bitTime / 2; i += m_bitTime)
+  {
+    m_currentByte >>= 1;
+    if (m_bitState == HIGH)
+      m_currentByte |= 0x8000;
+  }
+
+  m_bitState = bitState;
+  m_lastBitTime = endTime;
 }
 
-int SoftwareSerial::peek() {
-   if (!m_rxValid || (m_inPos == m_outPos)) return -1;
-   return m_buffer[m_outPos];
+void SoftwareSerial::commitFrame() {
+  if (m_frameCommitted)
+    return;
+
+  // set the frame as committed as soon as possible
+  m_frameCommitted = true;
+
+  updateFrame(m_bitState, m_frameStart + m_bitTime * (1 + 8 + 1));
+
+  if (m_invert)
+    m_currentByte = ~m_currentByte;
+  m_currentByte >>= 7;
+  
+  // Store the received value in the buffer unless we have an overflow
+  int next = (m_inPos + 1);
+  if (next >= m_buffSize)
+	next = 0;
+  if (next != m_inPos) {
+    m_buffer[m_inPos] = m_currentByte & 0xff;
+    m_inPos = next;
+  }
 }
 
-void ICACHE_RAM_ATTR SoftwareSerial::rxRead() {
-   unsigned long wait = m_bitTime;
-   unsigned long start = ESP.getCycleCount();
-   uint8_t rec = 0;
-   for (int i = 0; i < 8; i++) {
-     WAIT;
-     rec >>= 1;
-     if (digitalRead(m_rxPin))
-       rec |= 0x80;
-   }
-   if (m_invert) rec = ~rec;
-   // Stop bit
-   WAIT;
-   // Store the received value in the buffer unless we have an overflow
-   int next = (m_inPos+1) % m_buffSize;
-   if (next != m_inPos) {
-      m_buffer[m_inPos] = rec;
-      m_inPos = next;
-   }
-}
+void SoftwareSerial::rxRead() {
+  uint32_t now = ESP.getCycleCount();
 
-void ICACHE_RAM_ATTR SoftwareSerial::handle_interrupt(void *arg) {
-   uint32_t gpioStatus = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
-   // Clear the interrupt(s) otherwise we get called again
-   GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpioStatus);
-   ETS_GPIO_INTR_DISABLE();
-   uint8_t pin = 0;
-   while (gpioStatus) {
-      while(!(gpioStatus & (1 << pin))) pin++;
-      gpioStatus &= ~(1 << pin);
-      if (InterruptList[pin]) {
-         // For some reason there is always an interrupt directly after the
-         // stop bit. Detect that by checking if we have a start bit
-         if (digitalRead(pin) == InterruptList[pin]->m_invert)
-            InterruptList[pin]->rxRead();
-      }
-   }
-   ETS_GPIO_INTR_ENABLE();
+  if (now - m_lastBitTime > m_bitTime * (1 + 8 + 1)) {
+    commitFrame();
+    m_frameCommitted = false;
+    m_frameStart = now;
+    m_lastBitTime = now + m_bitTime; // skip the start bit
+  }
+
+  updateFrame(digitalRead(m_rxPin), now);
 }

--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -49,7 +49,7 @@ void SoftwareSerial::begin(long speed) {
   m_bitTime = ESP.getCpuFreqMHz() * 1000000 / speed;
   m_frameCommitted = true;
 
-  m_rxValid = digitalPinToInterrupt(receivePin) != NOT_AN_INTERRUPT;
+  m_rxValid = digitalPinToInterrupt(m_rxPin) != NOT_AN_INTERRUPT;
   if (m_buffer == NULL) {
     m_buffer = (uint8_t*)malloc(m_buffSize);
     if (m_buffer == NULL)

--- a/SoftwareSerial.h
+++ b/SoftwareSerial.h
@@ -61,8 +61,8 @@ class SoftwareSerial : public Stream
     void attachRxInterrupt();
     void detachRxInterrupt();
     void rxRead();
-    void commitFrame();
-    void updateFrame(uint8_t bitState, unsigned long const endTime);
+    void commitFrame(uint32_t endTime);
+    void updateFrame(uint8_t bitState, uint32_t endTime);
 
     // Member variables
     size_t m_buffSize;
@@ -76,7 +76,7 @@ class SoftwareSerial : public Stream
     uint32_t m_frameStart;
     uint8_t m_bitState;
     uint16_t m_currentByte;
-    uint32_t m_lastBitTime;
+    uint8_t m_lastBit;
     bool m_frameCommitted;
 
     static SoftwareSerial * M_instances[EXTERNAL_NUM_INTERRUPTS];

--- a/SoftwareSerial.h
+++ b/SoftwareSerial.h
@@ -39,6 +39,7 @@ class SoftwareSerial : public Stream
     ~SoftwareSerial();
 
     void begin(long speed);
+	void end();
 
     int peek() {
       if (!m_rxValid || (m_inPos == m_outPos)) return -1;

--- a/SoftwareSerial.h
+++ b/SoftwareSerial.h
@@ -82,11 +82,7 @@ class SoftwareSerial : public Stream
     static SoftwareSerial * M_instances[EXTERNAL_NUM_INTERRUPTS];
 
     template<uint8_t interrupt>
-    static void M_isr() {
-      register SoftwareSerial *thiz = M_instances[interrupt];
-      if (thiz != NULL)
-        thiz->rxRead();
-    }
+    static void M_isr();
 };
 
 // If only one tx or rx wanted then use this as parameter for the unused pin

--- a/SoftwareSerial.h
+++ b/SoftwareSerial.h
@@ -1,27 +1,27 @@
 /*
-SoftwareSerial.h
+  SoftwareSerial.h
 
-SoftwareSerial.cpp - Implementation of the Arduino software serial for ESP8266.
-Copyright (c) 2015 Peter Lerup. All rights reserved.
+  SoftwareSerial.cpp - Implementation of the Arduino software serial for ESP8266.
+  Copyright (c) 2015 Peter Lerup. All rights reserved.
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 
-#ifndef SoftwareSerial_h
-#define SoftwareSerial_h
+#ifndef EspSoftwareSerial_h
+#define EspSoftwareSerial_h
 
 #include <inttypes.h>
 #include <Stream.h>
@@ -34,40 +34,59 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 class SoftwareSerial : public Stream
 {
-public:
-   SoftwareSerial(int receivePin, int transmitPin, bool inverse_logic = false, unsigned int buffSize = 64);
-   ~SoftwareSerial();
+  public:
+    SoftwareSerial(int receivePin, int transmitPin, bool inverse_logic = false, unsigned int buffSize = 64);
+    ~SoftwareSerial();
 
-   void begin(long speed);
+    void begin(long speed);
 
-   int peek();
+    int peek() {
+      if (!m_rxValid || (m_inPos == m_outPos)) return -1;
+      return m_buffer[m_outPos];
+    }
 
-   virtual size_t write(uint8_t byte);
-   virtual int read();
-   virtual int available();
-   virtual void flush();
-   operator bool() {return m_rxValid || m_txValid;}
+    virtual size_t write(uint8_t byte);
+    virtual int read();
+    virtual int available();
+    virtual void flush() {
+      m_inPos = m_outPos = 0;
+    }
+    operator bool() {
+      return m_rxValid || m_txValid;
+    }
 
-   // Disable or enable interrupts on the rx pin
-   void enableRx(bool on);
+    using Print::write;
 
-   static void handle_interrupt(void *arg);
+  private:
+    void attachRxInterrupt();
+    void detachRxInterrupt();
+    void rxRead();
+    void commitFrame();
+    void updateFrame(uint8_t bitState, unsigned long const endTime);
 
-   using Print::write;
+    // Member variables
+    size_t m_buffSize;
+    uint8_t *m_buffer;
+    int m_rxPin, m_rxInterrupt, m_txPin;
+    bool m_rxValid, m_txValid;
+    bool m_invert;
+    uint32_t m_bitTime;
+    unsigned int m_inPos, m_outPos;
 
-private:
-   bool isValidGPIOpin(int pin);
-   void rxRead();
+    uint32_t m_frameStart;
+    uint8_t m_bitState;
+    uint16_t m_currentByte;
+    uint32_t m_lastBitTime;
+    bool m_frameCommitted;
 
-   // Member variables
-   int m_rxPin, m_txPin;
-   bool m_rxValid, m_txValid;
-   bool m_invert;
-   unsigned long m_bitTime;
-   unsigned int m_inPos, m_outPos;
-   int m_buffSize;
-   uint8_t *m_buffer;
+    static SoftwareSerial * M_instances[EXTERNAL_NUM_INTERRUPTS];
 
+    template<uint8_t interrupt>
+    static void M_isr() {
+      register SoftwareSerial *thiz = M_instances[interrupt];
+      if (thiz != NULL)
+        thiz->rxRead();
+    }
 };
 
 // If only one tx or rx wanted then use this as parameter for the unused pin


### PR DESCRIPTION
1. attempt to not break the arduino attachInterrupt()
2. interrupt-driven rx

needs review and testing, as there ARE issues...
i think your tree has more watches and would have more people help in testing.

Issues:
1. the first byte being transmit will always fail, because I can just never get the timing right, for some mystery reason...... I tried ICACHE_RAM_ATTR but didn't really help.
2. the interrupt on esp8266 has a high latency, which may cause rx to fail at high baudrate with many SoftwareSerial, or even when 2 rx overlaps, but I dunno why.
3. supports only 8n1...