### PR TITLE
Attach RX pin interrupt on begin(..) function if is necessary

### DIFF
--- a/SoftwareSerial.cpp
+++ b/SoftwareSerial.cpp
@@ -109,6 +109,9 @@ bool SoftwareSerial::isValidGPIOpin(int pin) {
 void SoftwareSerial::begin(long speed) {
    // Use getCycleCount() loop to get as exact timing as possible
    m_bitTime = ESP.getCpuFreqMHz()*1000000/speed;
+
+   if (!m_rxEnabled)
+     enableRx(true);
 }
 
 long SoftwareSerial::baudRate() {


### PR DESCRIPTION
Interrupt on RX pin was attached in constructor only. When you later decided to call `end()` function, there was no way to reattach interrupt on the RX pin again. This is actually inconsistent with original Arduino `SoftwareSerial`, where `begin(..)` function reattach the interrupt.