### PR TITLE
the destructor should be virtual

### DIFF
--- a/SoftwareSerial.h
+++ b/SoftwareSerial.h
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 class SoftwareSerial : public Stream {
 public:
   SoftwareSerial(int receivePin, int transmitPin, bool inverse_logic = false, unsigned int buffSize = 64);
-  ~SoftwareSerial();
+  virtual ~SoftwareSerial();
 
   void begin(long speed);
   long baudRate();


### PR DESCRIPTION
This allows to use 'serial = new SoftwareSerial(3,1);' and 'delete serial;'
*after* Serial.swap(), to still have a serial port on usbserial chips
while having the faster hardware serial port available on GPIO13+15.