### PR TITLE
Throw major release number to stop confusion over ctor/begin() split …

### DIFF
--- a/examples/loopback/loopback.ino
+++ b/examples/loopback/loopback.ino
@@ -86,7 +86,7 @@ void setup() {
     Serial.begin(IUTBITRATE);
     Serial.swap();
     Serial.setRxBufferSize(2 * BLOCKSIZE);
-    logger.begin(9600, -1, TX);
+    logger.begin(9600, swSerialConfig, -1, TX);
 #else
     Serial.begin(9600);
 #endif
@@ -96,7 +96,7 @@ void setup() {
     Serial2.setRxBufferSize(2 * BLOCKSIZE);
     logger.begin(9600);
 #elif defined(HWSOURCESINK)
-    serialIUT.begin(IUTBITRATE, SERIAL_8N1, D5, D6);
+    serialIUT.begin(IUTBITRATE, swSerialConfig, D5, D6);
     serialIUT.setRxBufferSize(2 * BLOCKSIZE);
     logger.begin(9600);
 #else
@@ -108,12 +108,12 @@ void setup() {
 
 #if !defined(HWSOURCESINK)
 #if defined(ESP8266)
-    serialIUT.begin(IUTBITRATE, D5, D6, swSerialConfig, false, 4 * BLOCKSIZE);
+    serialIUT.begin(IUTBITRATE, swSerialConfig, D5, D6, false, 4 * BLOCKSIZE);
 #ifdef HALFDUPLEX
     serialIUT.enableIntTx(false);
 #endif
 #elif defined(ESP32)
-    serialIUT.begin(IUTBITRATE, D5, D6, swSerialConfig, false, 2 * BLOCKSIZE);
+    serialIUT.begin(IUTBITRATE, swSerialConfig, D5, D6, false, 2 * BLOCKSIZE);
 #ifdef HALFDUPLEX
     serialIUT.enableIntTx(false);
 #endif

--- a/examples/onewiretest/onewiretest.ino
+++ b/examples/onewiretest/onewiretest.ino
@@ -8,9 +8,9 @@ void setup() {
 	delay(2000);
 	Serial.begin(115200);
 	Serial.println("\nOne Wire Half Duplex Serial Tester");
-	swSer1.begin(115200, 12, 12, SWSERIAL_8N1, false, 256);
+	swSer1.begin(115200, SWSERIAL_8N1, 12, 12, false, 256);
 	swSer1.enableIntTx(true);
-	swSer2.begin(115200, 14, 14, SWSERIAL_8N1, false, 256);
+	swSer2.begin(115200, SWSERIAL_8N1, 14, 14, false, 256);
 	swSer2.enableIntTx(true);
 }
 

--- a/examples/repeater/repeater.ino
+++ b/examples/repeater/repeater.ino
@@ -56,7 +56,7 @@ void setup() {
 	repeater.begin(IUTBITRATE);
 	repeater.setRxBufferSize(2 * BLOCKSIZE);
 	repeater.swap();
-	logger.begin(9600, RX, TX);
+	logger.begin(9600, swSerialConfig, RX, TX);
 #elif defined(ESP32)
 	repeater.begin(IUTBITRATE, SERIAL_8N1, D7, D8);
 	repeater.setRxBufferSize(2 * BLOCKSIZE);
@@ -64,9 +64,9 @@ void setup() {
 #endif
 #else
 #if defined(ESP8266)
-	repeater.begin(IUTBITRATE, D7, D8, swSerialConfig, false, 2 * BLOCKSIZE);
+	repeater.begin(IUTBITRATE, swSerialConfig, D7, D8, false, 2 * BLOCKSIZE);
 #elif defined(ESP32)
-	repeater.begin(IUTBITRATE, D7, D8, swSerialConfig, false, 2 * BLOCKSIZE);
+	repeater.begin(IUTBITRATE, swSerialConfig, D7, D8, false, 2 * BLOCKSIZE);
 #endif
 #ifdef HALFDUPLEX
 	repeater.enableIntTx(false);

--- a/examples/servoTester/servoTester.ino
+++ b/examples/servoTester/servoTester.ino
@@ -12,7 +12,7 @@ void setup() {
 	delay(2000);
 	Serial.begin(115200);
 	Serial.println("\nAlpha 1S Servo Tester");
-	swSer.begin(115200, 12, 12, SWSERIAL_8N1, false, 256);
+	swSer.begin(115200, SWSERIAL_8N1, 12, 12, false, 256);
 }
 
 void loop() {

--- a/examples/swsertest/swsertest.ino
+++ b/examples/swsertest/swsertest.ino
@@ -24,7 +24,7 @@ SoftwareSerial swSer;
 
 void setup() {
 	Serial.begin(115200);
-	swSer.begin(BAUD_RATE, D5, D6, SWSERIAL_8N1, false, 95, 11);
+	swSer.begin(BAUD_RATE, SWSERIAL_8N1, D5, D6, false, 95, 11);
 
 	Serial.println("\nSoftware serial test started");
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EspSoftwareSerial",
-    "version": "5.4.0",
+    "version": "6.0.0",
     "keywords": [
       "serial", "io", "softwareserial"
     ],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EspSoftwareSerial
-version=5.4.0
+version=6.0.0
 author=Peter Lerup, Dirk Kaar
 maintainer=Peter Lerup <peter@lerup.com>
 sentence=Implementation of the Arduino software serial for ESP8266/ESP32.

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -28,9 +28,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <Stream.h>
 #include <functional>
 
-/// If only one tx or rx wanted then use this as parameter for the unused pin.
-constexpr int SW_SERIAL_UNUSED_PIN = -1;
-
 enum SoftwareSerialConfig {
     SWSERIAL_5N1 = 0,
     SWSERIAL_6N1,
@@ -47,11 +44,25 @@ enum SoftwareSerialConfig {
 class SoftwareSerial : public Stream {
 public:
     SoftwareSerial();
+    /// Ctor to set defaults for pins.
+    /// @param rxPin the GPIO pin used for RX
+    /// @param txPin -1 for onewire protocol, GPIO pin used for twowire TX
+    SoftwareSerial(int8_t rxPin, int8_t txPin = -1);
     SoftwareSerial(const SoftwareSerial&) = delete;
     SoftwareSerial& operator= (const SoftwareSerial&) = delete;
     virtual ~SoftwareSerial();
-    void begin(uint32_t baud, int8_t rxPin, int8_t txPin = -1,
-        SoftwareSerialConfig config = SWSERIAL_8N1,
+    /// Configure the SoftwareSerial object for use.
+    /// @param baud the TX/RX bitrate
+    /// @param config sets databits, parity, and stop bit count
+    /// @param rxPin -1 or default: either no RX pin, or keeps the rxPin set in the ctor
+    /// @param txPin -1 or default: either no TX pin (onewire), or keeps the txPin set in the ctor
+    /// @param invert true: uses invert line level logic
+    /// @param bufCapacity the capacity for the received bytes buffer
+    /// @param isrBufCapacity 0: derived from bufCapacity. The capacity of the internal asynchronous
+    ///	       bit receive buffer, a suggested size is bufCapacity times the sum of
+    ///	       start, data, parity and stop bit count.
+    void begin(uint32_t baud, SoftwareSerialConfig config = SWSERIAL_8N1,
+        int8_t rxPin = -1, int8_t txPin = -1,
         bool invert = false, int bufCapacity = 64, int isrBufCapacity = 0);
     uint32_t baudRate();
     /// Transmit control pin.
@@ -126,9 +137,9 @@ private:
 
     // Member variables
     bool m_oneWire;
-    int8_t m_rxPin = SW_SERIAL_UNUSED_PIN;
-    int8_t m_txPin = SW_SERIAL_UNUSED_PIN;
-    int8_t m_txEnablePin = SW_SERIAL_UNUSED_PIN;
+    int8_t m_rxPin = -1;
+    int8_t m_txPin = -1;
+    int8_t m_txEnablePin = -1;
     bool m_rxValid = false;
     bool m_rxEnabled = false;
     bool m_txValid = false;


### PR DESCRIPTION
…of rx/tx pin setting.

For complete maximum default parameter uses, this is now backward compatible with releases 5.0.4 and prior.