### PR TITLE
UART0 pins enabled for ESPSoftwareSerial

### DIFF
--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -50,7 +50,7 @@ bool SoftwareSerial::isValidGPIOpin(int8_t pin) {
 #if defined(ESP8266)
     return (pin >= 0 && pin <= 5) || (pin >= 12 && pin <= 15);
 #elif defined(ESP32)
-    return pin == 0 || pin == 2 || (pin >= 4 && pin <= 5) || (pin >= 12 && pin <= 19) ||
+    return pin == 1 || pin == 3 || pin == 0 || pin == 2 || (pin >= 4 && pin <= 5) || (pin >= 12 && pin <= 19) ||
         (pin >= 21 && pin <= 23) || (pin >= 25 && pin <= 27) || (pin >= 32 && pin <= 35);
 #else
     return true;
@@ -70,7 +70,7 @@ void SoftwareSerial::begin(uint32_t baud, SoftwareSerialConfig config,
     m_pduBits = m_dataBits + static_cast<bool>(m_parityMode) + m_stopBits;
     m_bitCycles = (ESP.getCpuFreqMHz() * 1000000UL + baud / 2) / baud;
     m_intTxEnabled = true;
-    if (isValidGPIOpin(m_rxPin)) {
+    if (isValidGPIOpin(m_rxPin) && (m_rxPin != 1) ) {
         std::unique_ptr<circular_queue<uint8_t> > buffer(new circular_queue<uint8_t>((bufCapacity > 0) ? bufCapacity : 64));
         m_buffer = move(buffer);
         if (m_parityMode)
@@ -86,7 +86,7 @@ void SoftwareSerial::begin(uint32_t baud, SoftwareSerialConfig config,
             pinMode(m_rxPin, INPUT_PULLUP);
         }
     }
-    if (isValidGPIOpin(m_txPin)
+    if (isValidGPIOpin(m_txPin) && (m_txPin != 3)
 #ifdef ESP8266
         || ((m_txPin == 16) && !m_oneWire)) {
 #else


### PR DESCRIPTION
That changes tested and works fine.
Was forced to do it because of issue https://github.com/plerup/espsoftwareserial/issues/133
So, now Im able to use 3x HW UART for communication with sensors and for minor diagnostics to PC maintained by SW Uart. It uses only TX, so, Im safe from https://github.com/plerup/espsoftwareserial/issues/133 (it crashes in my config only on RX events).

Sample code I sed for debug:

```
#define  NO_GLOBAL_SERIAL
// in sloeber need to add attribute in
// project properties/arduino/Compiler options/Add for C and C++
// -DNO_GLOBAL_SERIAL
// to use Serial variable name for SWUART

#include <SoftwareSerial.h>


	#define PM_SERIAL_RX    35	// SDS
	#define PM_SERIAL_TX    32	// SDS

	#define PM2_SERIAL_RX   25  // PMS
	#define PM2_SERIAL_TX   26	// PMS

	#define GPS_SERIAL_RX   16  // UART2
	#define GPS_SERIAL_TX   17

	#define DEB_RX    3
	#define DEB_TX    1

// Reminder: the buffer size optimizations here, in particular the isrBufSize that only accommodates
// a single 8N1 word, are on the basis that any char written to the loopback SoftwareSerial adapter gets read
// before another write is performed. Block writes with a size greater than 1 would usually fail. 

SoftwareSerial Serial;
HardwareSerial serialSDS(0);
HardwareSerial serialPMS(1);
HardwareSerial serialGPS(2);

void setup() {

	serialSDS.begin(9600, SERIAL_8N1, PM_SERIAL_RX,  PM_SERIAL_TX);			 		// for HW UART SDS
	serialPMS.begin(9600, SERIAL_8N1, PM2_SERIAL_RX, PM2_SERIAL_TX);			 	// for HW UART PMS
	serialGPS.begin(9600, SERIAL_8N1, GPS_SERIAL_RX, GPS_SERIAL_TX);			 	// for HW UART GPS

	gpio_pad_select_gpio(DEB_RX);
	gpio_pad_select_gpio(DEB_TX);
	//pinMode(DEB_RX, INPUT);
	//pinMode(DEB_TX, OUTPUT);

	Serial.begin(9600, SWSERIAL_8N1, DEB_RX, DEB_TX, false, 295, 11);

	Serial.println("\nSoftware serial test started");

	for (char ch = ' '; ch <= 'z'; ch++) {
		Serial.write(ch);
	}
	Serial.println("");
}

void loop() {
	//if (SerialSW.available() > 0) {
	//	SerialSW.write(SerialSW.rea);
	//	yield();
	//}
	   Serial.println("Hello");
	serialSDS.println("serialSDS 0");
	serialPMS.println("serialPMS 1");
	serialGPS.println("serialGPS 2");

	delay(100);
	yield();
}
```
