### PR TITLE
Arduino API extension: Stream::to()

### DIFF
--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -187,9 +187,10 @@ int SoftwareSerial::read() {
     return val;
 }
 
-size_t SoftwareSerial::read(uint8_t* buffer, size_t size) {
+
+streamInt SoftwareSerial::read(uint8_t* buffer, size_t size) {
     if (!m_rxValid) { return 0; }
-    size_t avail;
+    streamInt avail;
     if (0 == (avail = m_buffer->pop_n(buffer, size))) {
         rxBits();
         avail = m_buffer->pop_n(buffer, size);

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -78,6 +78,12 @@ enum SoftwareSerialConfig {
     SWSERIAL_8S2,
 };
 
+#if STREAM_READ_RETURNS_INT // stream:to*()
+using streamInt = int;
+#else
+using streamInt = size_t;
+#endif
+
 /// This class is compatible with the corresponding AVR one, however,
 /// the constructor takes no arguments, for compatibility with the
 /// HardwareSerial class.
@@ -152,9 +158,9 @@ public:
         return (0x9669 >> byte) & 1;
     }
     /// The read(buffer, size) functions are non-blocking, the same as readBytes but without timeout
-    size_t read(uint8_t* buffer, size_t size);
+    streamInt read(uint8_t* buffer, size_t size);
     /// The read(buffer, size) functions are non-blocking, the same as readBytes but without timeout
-    size_t read(char* buffer, size_t size) {
+    streamInt read(char* buffer, size_t size) {
         return read(reinterpret_cast<uint8_t*>(buffer), size);
     }
     /// @returns The number of bytes read into buffer, up to size. Times out if the limit set through


### PR DESCRIPTION
An Arduino API extension in progress imports `Client::read(buffer)` definition to `Stream::read(buffer)`.
This method returns an int. 

Other classes inheriting from `Stream::` which implement the same (non-virtual) function return a `size_t` (HardwareSerial, SoftwareSerial, FS). The function now exists, is virtual, and is an attempt to make the API coherent and able to implement `Stream::to*()` functions. With more helpers in SoftwareSerial, buffers *could* be transferred using less copies / less intermediate buffers and less code.

These helpers could be added in SoftwareSerial too in a separate PR.

This is related to https://github.com/esp8266/Arduino/pull/6979 and specifically https://github.com/esp8266/Arduino/pull/6979/commits/cdd72f9a2443d9ada9efb295f429a20c74e42206