### PR TITLE
Enable use of input-only ESP32 GPIO

### DIFF
--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -215,6 +215,9 @@ private:
         uint32_t dutyCycle, uint32_t offCycle, bool withStopBit);
     bool isValidGPIOpin(int8_t pin);
     bool isValidRxGPIOpin(int8_t pin);
+    bool isValidTxGPIOpin(int8_t pin);
+    // result is only defined for a valid Rx GPIO pin
+    bool hasRxGPIOPullUp(int8_t pin);
     /* check m_rxValid that calling is safe */
     void rxBits();
     void rxBits(const uint32_t& isrCycle);


### PR DESCRIPTION
ESP32 has GPIOs 34-39 that are input only, without internal pull-up. Make them available.