### PR TITLE
Improve support for ESP32 S2 and ESP32C3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EspSoftwareSerial
 
-## Implementation of the Arduino software serial library for the ESP8266 / ESP32
+## Implementation of the Arduino software serial library for the ESP8266 / ESP32 family
 
 This fork implements interrupt service routine best practice.
 In the receive interrupt, instead of blocking for whole bytes
@@ -26,6 +26,8 @@ Please note that due to the fact that the ESPs always have other activities
 ongoing, there will be some inexactness in interrupt timings. This may
 lead to inevitable, but few, bit errors when having heavy data traffic
 at high baud rates.
+
+This library supports ESP8266, ESP32, ESP32-S2 and ESP32-C3 devices
 
 ## Resource optimization
 
@@ -96,6 +98,43 @@ parity bit to every byte sent, setting it to logical zero (SPACE parity).
 To detect incoming bytes with the parity bit set (MARK parity), use the
 ``readParity()`` function. To send a byte with the parity bit set, just add
 ``MARK`` as the second argument when writing, e.g. ``write(ch, SWSERIAL_PARITY_MARK)``.
+
+## Checking for correct pin selection / configuration 
+In general, most pins on the ESP8266 and ESP32 devices can be used by SoftwareSerial, 
+however each device has a number of pins that have special functions or require careful
+handling to prevent undesirable situations, for example they are connected to the 
+on-board SPI flash memory or they are used to determine boot and programming modes 
+after powerup or brownouts. These pins are not able to be configured by this library.
+
+The exact list for each device can be found in the [ESP32 data sheet](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)
+in sections 2.2 (Pin Descriptions) and 2.4 (Strapping pins) or by referring to the
+``isValidGPIOpin()``, ``isValidRxGPIOpin()`` and ``isValidTxGPIOpin()`` functions
+
+The easiest and safest method is to test the object returned at runtime, to see if 
+its valid. For example:
+
+```
+#include <SoftwareSerial.h>
+
+#define MYPORT_TX	12
+#define MYPORT_RX	13
+
+SoftwareSerial myPort;
+
+
+....
+
+
+Serial.begin(115200);		// Standard hardware serial port
+
+myPort.begin(38400, SWSERIAL_8N1, MYPORT_RX, MYPORT_TX, false, 256, 256);
+if (!myPort) {
+  Serial.println("Invalid pin configuration, check config"); 
+  while (1) ;
+} 
+
+....
+```
 
 ## Using and updating EspSoftwareSerial in the esp8266com/esp8266 Arduino build environment
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ongoing, there will be some inexactness in interrupt timings. This may
 lead to inevitable, but few, bit errors when having heavy data traffic
 at high baud rates.
 
-This library supports ESP8266, ESP32, ESP32-S2 and ESP32-C3 devices
+This library supports ESP8266, ESP32, ESP32-S2 and ESP32-C3 devices.
 
 ## Resource optimization
 
@@ -127,10 +127,13 @@ SoftwareSerial myPort;
 
 Serial.begin(115200);		// Standard hardware serial port
 
-myPort.begin(38400, SWSERIAL_8N1, MYPORT_RX, MYPORT_TX, false, 256, 256);
-if (!myPort) {
-  Serial.println("Invalid pin configuration, check config"); 
-  while (1) ;
+myPort.begin(38400, SWSERIAL_8N1, MYPORT_RX, MYPORT_TX, false);
+if (!myPort) {			// If the object did not initilaise, then its configuration is invalid
+  Serial.println("Invalid SoftwareSerial pin configuration, check config"); 
+  while (1) {			// Can't continue with invalid configuration
+	yield();
+	delay (1000);
+  }
 } 
 
 ....

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -49,13 +49,16 @@ SoftwareSerial::~SoftwareSerial() {
 bool SoftwareSerial::isValidGPIOpin(int8_t pin) {
 #if defined(ESP8266)
     return (pin >= 0 && pin <= 16) && !isFlashInterfacePin(pin);
-#elif defined(ESP32)
 
+#elif defined(ESP32)
+  // Remove the strapping pins as defined in the datasheets, they affect bootup and other critical operations
+  // Remmove the flash memory pins on related devices, since using these causes memory access issues.
   #ifdef CONFIG_IDF_TARGET_ESP32
     // Datasheet https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf,
-    // Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32/_images/esp32-devkitC-v4-pinout.jpg
-    return (pin >= 0 && pin <= 5) || (pin >= 12 && pin <= 19) ||
-        (pin >= 21 && pin <= 23) || (pin >= 25 && pin <= 27) || (pin >= 32 && pin <= 39);
+    // Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32/_images/esp32-devkitC-v4-pinout.jpg    
+	return (pin >= 1  && pin <= 1)  || (pin >= 3  && pin <= 4)  || (pin >= 13 && pin <= 14) ||
+		   (pin >= 16 && pin <= 19) || (pin >= 21 && pin <= 23) || (pin >= 25 && pin <= 27) || 
+		   (pin >= 32 && pin <= 39);
 
   #elif CONFIG_IDF_TARGET_ESP32S2
     // Datasheet https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf,
@@ -88,10 +91,10 @@ bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) {
     return isValidGPIOpin(pin)
 #if defined(ESP32)
 	#ifdef CONFIG_IDF_TARGET_ESP32
-        && (pin < 34)			
+        && (pin < 34)		// GPIO34 and above are input only, so cannot transmit	
     
 	#elif CONFIG_IDF_TARGET_ESP32S2
-        && (pin < 45)        
+        && (pin < 46)       // GPIO46 is an input only, so cannot transmit 
 	
 	#elif CONFIG_IDF_TARGET_ESP32C3
 		// Nothing to do

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -50,8 +50,27 @@ bool SoftwareSerial::isValidGPIOpin(int8_t pin) {
 #if defined(ESP8266)
     return (pin >= 0 && pin <= 16) && !isFlashInterfacePin(pin);
 #elif defined(ESP32)
+
+  #ifdef CONFIG_IDF_TARGET_ESP32
+    // Datasheet https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf,
+    // Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32/_images/esp32-devkitC-v4-pinout.jpg
     return (pin >= 0 && pin <= 5) || (pin >= 12 && pin <= 19) ||
         (pin >= 21 && pin <= 23) || (pin >= 25 && pin <= 27) || (pin >= 32 && pin <= 39);
+
+  #elif CONFIG_IDF_TARGET_ESP32S2
+    // Datasheet https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf,
+    // Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/_images/esp32-s2_saola1-pinout.jpg
+    return (pin >= 1 && pin <= 21) || (pin >= 33 && pin <= 44);
+  
+  #elif CONFIG_IDF_TARGET_ESP32C3
+	// Datasheet https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf, 
+	// Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/_images/esp32-c3-devkitm-1-v1-pinout.jpg
+    return (pin >= 0 && pin <= 1) || (pin >= 3 && pin <= 7) || (pin >= 18 && pin <= 21);
+  
+  #else 
+    return true;
+  #endif
+	
 #else
     return true;
 #endif
@@ -68,7 +87,16 @@ bool SoftwareSerial::isValidRxGPIOpin(int8_t pin) {
 bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) {
     return isValidGPIOpin(pin)
 #if defined(ESP32)
-        && (pin < 34)
+	#ifdef CONFIG_IDF_TARGET_ESP32
+        && (pin < 34)			
+    
+	#elif CONFIG_IDF_TARGET_ESP32S2
+        && (pin < 45)        
+	
+	#elif CONFIG_IDF_TARGET_ESP32C3
+		// Nothing to do
+	#endif
+
 #endif
         ;
 }


### PR DESCRIPTION
Clarified documentation for supportability of newer ESP32 variants

Added info on how to check if the selected pins are valid

Corrects pin validation for ESP32 S2 and ESP32 C3 devices