### PR TITLE
Implement tx open drain.

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EspSoftwareSerial",
-    "version": "6.16.1",
+    "version": "6.17.0",
     "description": "Implementation of the Arduino software serial for ESP8266/ESP32.",
     "keywords": [
         "serial", "io", "softwareserial"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EspSoftwareSerial
-version=6.16.1
+version=6.17.0
 author=Dirk Kaar, Peter Lerup
 maintainer=Dirk Kaar <dok@dok-net.net>
 sentence=Implementation of the Arduino software serial for ESP8266/ESP32.

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -69,7 +69,7 @@ SoftwareSerial::~SoftwareSerial() {
     end();
 }
 
-bool SoftwareSerial::isValidGPIOpin(int8_t pin) {
+constexpr bool SoftwareSerial::isValidGPIOpin(int8_t pin) const {
 #if defined(ESP8266)
     return (pin >= 0 && pin <= 16) && !isFlashInterfacePin(pin);
 #elif defined(ESP32)
@@ -99,7 +99,7 @@ bool SoftwareSerial::isValidGPIOpin(int8_t pin) {
 #endif
 }
 
-bool SoftwareSerial::isValidRxGPIOpin(int8_t pin) {
+constexpr bool SoftwareSerial::isValidRxGPIOpin(int8_t pin) const {
     return isValidGPIOpin(pin)
 #if defined(ESP8266)
         && (pin != 16)
@@ -107,7 +107,7 @@ bool SoftwareSerial::isValidRxGPIOpin(int8_t pin) {
         ;
 }
 
-bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) {
+constexpr bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) const {
     return isValidGPIOpin(pin)
 #if defined(ESP32)
 #ifdef CONFIG_IDF_TARGET_ESP32
@@ -121,7 +121,7 @@ bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) {
         ;
 }
 
-bool SoftwareSerial::hasRxGPIOPullUp(int8_t pin) {
+constexpr bool SoftwareSerial::hasRxGPIOPullUp(int8_t pin) const {
 #if defined(ESP32)
     return !(pin >= 34 && pin <= 39);
 #else

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -51,14 +51,14 @@ constexpr uint8_t BYTE_ALL_BITS_SET = ~static_cast<uint8_t>(0);
 
 SoftwareSerial::SoftwareSerial() {
     m_isrOverflow = false;
-    m_rxGPIOPullupEnabled = true;
+    m_rxGPIOPullUpEnabled = true;
     m_txGPIOOpenDrain = false;
 }
 
 SoftwareSerial::SoftwareSerial(int8_t rxPin, int8_t txPin, bool invert)
 {
     m_isrOverflow = false;
-    m_rxGPIOPullupEnabled = true;
+    m_rxGPIOPullUpEnabled = true;
     m_txGPIOOpenDrain = false;
     m_rxPin = rxPin;
     m_txPin = txPin;
@@ -132,7 +132,7 @@ bool SoftwareSerial::hasRxGPIOPullUp(int8_t pin) {
 
 void SoftwareSerial::setRxGPIOPinMode() {
     if (m_rxValid) {
-        pinMode(m_rxPin, hasRxGPIOPullUp(m_rxPin) && m_rxGPIOPullupEnabled ? INPUT_PULLUP : INPUT);
+        pinMode(m_rxPin, hasRxGPIOPullUp(m_rxPin) && m_rxGPIOPullUpEnabled ? INPUT_PULLUP : INPUT);
     }
 }
 
@@ -218,8 +218,8 @@ void SoftwareSerial::enableIntTx(bool on) {
     m_intTxEnabled = on;
 }
 
-void SoftwareSerial::enableRxGPIOPullup(bool on) {
-    m_rxGPIOPullupEnabled = on;
+void SoftwareSerial::enableRxGPIOPullUp(bool on) {
+    m_rxGPIOPullUpEnabled = on;
     setRxGPIOPinMode();
 }
 

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -69,7 +69,10 @@ SoftwareSerial::~SoftwareSerial() {
     end();
 }
 
-constexpr bool SoftwareSerial::isValidGPIOpin(int8_t pin) const {
+#if __GNUC__ >= 10
+constexpr
+#endif
+bool SoftwareSerial::isValidGPIOpin(int8_t pin) const {
 #if defined(ESP8266)
     return (pin >= 0 && pin <= 16) && !isFlashInterfacePin(pin);
 #elif defined(ESP32)
@@ -99,7 +102,10 @@ constexpr bool SoftwareSerial::isValidGPIOpin(int8_t pin) const {
 #endif
 }
 
-constexpr bool SoftwareSerial::isValidRxGPIOpin(int8_t pin) const {
+#if __GNUC__ >= 10
+constexpr
+#endif
+bool SoftwareSerial::isValidRxGPIOpin(int8_t pin) const {
     return isValidGPIOpin(pin)
 #if defined(ESP8266)
         && (pin != 16)
@@ -107,7 +113,10 @@ constexpr bool SoftwareSerial::isValidRxGPIOpin(int8_t pin) const {
         ;
 }
 
-constexpr bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) const {
+#if __GNUC__ >= 10
+constexpr
+#endif
+bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) const {
     return isValidGPIOpin(pin)
 #if defined(ESP32)
 #ifdef CONFIG_IDF_TARGET_ESP32
@@ -121,7 +130,10 @@ constexpr bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) const {
         ;
 }
 
-constexpr bool SoftwareSerial::hasRxGPIOPullUp(int8_t pin) const {
+#if __GNUC__ >= 10
+constexpr
+#endif
+bool SoftwareSerial::hasRxGPIOPullUp(int8_t pin) const {
 #if defined(ESP32)
     return !(pin >= 34 && pin <= 39);
 #else

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -235,7 +235,7 @@ void SoftwareSerial::enableRxGPIOPullUp(bool on) {
     setRxGPIOPinMode();
 }
 
-void SoftwareSerial::enableTxOpenDrain(bool on) {
+void SoftwareSerial::enableTxGPIOOpenDrain(bool on) {
     m_txGPIOOpenDrain = on;
     setTxGPIOPinMode();
 }

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -126,6 +126,8 @@ public:
     void enableIntTx(bool on);
     /// Enable (default) or disable internal rx GPIO pullup.
     void enableRxGPIOPullup(bool on);
+    /// Enable or disable (default) tx GPIO output mode.
+    void enableTxOpenDrain(bool on);
 
     bool overflow();
 
@@ -227,7 +229,9 @@ private:
     // result is only defined for a valid Rx GPIO pin
     bool hasRxGPIOPullUp(int8_t pin);
     // safely set the pin mode for the Rx GPIO pin
-    void setRxGPIOPullUp();
+    void setRxGPIOPinMode();
+    // safely set the pin mode for the Tx GPIO pin
+    void setTxGPIOPinMode();
     /* check m_rxValid that calling is safe */
     void rxBits();
     void rxBits(const uint32_t isrCycle);
@@ -258,6 +262,7 @@ private:
     uint8_t m_pduBits;
     bool m_intTxEnabled;
     bool m_rxGPIOPullupEnabled;
+    bool m_txGPIOOpenDrain;
     SoftwareSerialParity m_parityMode;
     uint8_t m_stopBits;
     bool m_lastReadParity;

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -223,11 +223,11 @@ private:
     // If offCycle == 0, the level remains unchanged from dutyCycle.
     void writePeriod(
         uint32_t dutyCycle, uint32_t offCycle, bool withStopBit);
-    bool isValidGPIOpin(int8_t pin);
-    bool isValidRxGPIOpin(int8_t pin);
-    bool isValidTxGPIOpin(int8_t pin);
+    constexpr bool isValidGPIOpin(int8_t pin) const;
+    constexpr bool isValidRxGPIOpin(int8_t pin) const;
+    constexpr bool isValidTxGPIOpin(int8_t pin) const;
     // result is only defined for a valid Rx GPIO pin
-    bool hasRxGPIOPullUp(int8_t pin);
+    constexpr bool hasRxGPIOPullUp(int8_t pin) const;
     // safely set the pin mode for the Rx GPIO pin
     void setRxGPIOPinMode();
     // safely set the pin mode for the Tx GPIO pin

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -127,7 +127,7 @@ public:
     /// Enable (default) or disable internal rx GPIO pull-up.
     void enableRxGPIOPullUp(bool on);
     /// Enable or disable (default) tx GPIO output mode.
-    void enableTxOpenDrain(bool on);
+    void enableTxGPIOOpenDrain(bool on);
 
     bool overflow();
 

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -124,8 +124,8 @@ public:
     void setTransmitEnablePin(int8_t txEnablePin);
     /// Enable (default) or disable interrupts during tx.
     void enableIntTx(bool on);
-    /// Enable (default) or disable internal rx GPIO pullup.
-    void enableRxGPIOPullup(bool on);
+    /// Enable (default) or disable internal rx GPIO pull-up.
+    void enableRxGPIOPullUp(bool on);
     /// Enable or disable (default) tx GPIO output mode.
     void enableTxOpenDrain(bool on);
 
@@ -261,7 +261,7 @@ private:
     /// PDU bits include data, parity and stop bits; the start bit is not counted.
     uint8_t m_pduBits;
     bool m_intTxEnabled;
-    bool m_rxGPIOPullupEnabled;
+    bool m_rxGPIOPullUpEnabled;
     bool m_txGPIOOpenDrain;
     SoftwareSerialParity m_parityMode;
     uint8_t m_stopBits;


### PR DESCRIPTION
To switch the TX between default `OUTPUT` and `OUTPUT_OPEN_DRAIN` modes, a function `enableTxOpenDrain()` is added to the API.