### PR TITLE
Refactor CPU cycles to microseconds

### DIFF
--- a/examples/bitpattern/bitpattern.ino
+++ b/examples/bitpattern/bitpattern.ino
@@ -27,17 +27,19 @@ auto logSer = Serial;
 auto hwSer = Serial1;
 #endif
 
+constexpr uint32_t TESTBPS = 115200;
+
 void setup() {
 	delay(2000);
 #ifdef ESP8266
-	hwSer.begin(115200, SERIAL_8N1);
+	hwSer.begin(TESTBPS, SERIAL_8N1);
 	hwSer.swap();
 #else
-	hwSer.begin(115200, SERIAL_8N1, -1, D5);
+	hwSer.begin(TESTBPS, SERIAL_8N1, D6, D5);
 #endif
 	logSer.begin(115200);
 	logSer.println(PSTR("\nOne Wire Half Duplex Bitpattern and Datarate Test"));
-	swSer.begin(115200, SWSERIAL_8N1, -1, D5);
+	swSer.begin(TESTBPS, SWSERIAL_8N1, D6, D5);
 	swSer.enableIntTx(true);
 	logSer.println(PSTR("Tx on swSer"));
 }

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -292,8 +292,12 @@ size_t SoftwareSerial::readBytes(uint8_t* buffer, size_t size) {
         auto readCnt = read(&buffer[count], size - count);
         count += readCnt;
         if (count >= size) break;
-        if (readCnt) start = millis();
-        else optimistic_yield(1000UL);
+        if (readCnt) {
+            start = millis();
+        }
+        else {
+            optimistic_yield(1000UL);
+        }
     } while (millis() - start < _timeout);
     return count;
 }
@@ -350,11 +354,12 @@ void IRAM_ATTR SoftwareSerial::writePeriod(
 #endif
         m_periodDuration += dutyCycle;
         if (offCycle || (withStopBit && !m_invert)) {
-                if (!withStopBit || m_invert) {
-			preciseDelay();
-                } else {
-			lazyDelay();
-                }
+            if (!withStopBit || m_invert) {
+                preciseDelay();
+            }
+            else {
+                lazyDelay();
+            }
         }
     }
     if (offCycle)

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -613,7 +613,7 @@ void IRAM_ATTR SoftwareSerial::rxBitISR(SoftwareSerial* self) {
 
 void IRAM_ATTR SoftwareSerial::rxBitSyncISR(SoftwareSerial* self) {
     uint32_t start = micros();
-    uint32_t wait = self->m_bitTicks - 172U;
+    uint32_t wait = self->m_bitTicks - 2U;
 
     bool level = self->m_invert;
     // Store level and tick in the buffer unless we have an overflow

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -145,7 +145,7 @@ void SoftwareSerial::begin(uint32_t baud, SoftwareSerialConfig config,
     m_parityMode = static_cast<SoftwareSerialParity>(config & 070);
     m_stopBits = 1 + ((config & 0300) ? 1 : 0);
     m_pduBits = m_dataBits + static_cast<bool>(m_parityMode) + m_stopBits;
-    m_bitCycles = (ESP.getCpuFreqMHz() * 1000000UL + baud / 2) / baud;
+    m_bitTicks = (1000000UL + baud / 2) / baud;
     m_intTxEnabled = true;
     if (isValidRxGPIOpin(m_rxPin)) {
         m_rxReg = portInputRegister(digitalPinToPort(m_rxPin));
@@ -191,7 +191,7 @@ void SoftwareSerial::end()
 }
 
 uint32_t SoftwareSerial::baudRate() {
-    return ESP.getCpuFreqMHz() * 1000000UL / m_bitCycles;
+    return 1000000UL / m_bitTicks;
 }
 
 void SoftwareSerial::setTransmitEnablePin(int8_t txEnablePin) {
@@ -233,9 +233,9 @@ void SoftwareSerial::enableRx(bool on) {
     if (m_rxValid && on != m_rxEnabled) {
         if (on) {
             m_rxLastBit = m_pduBits - 1;
-            // Init to stop bit level and current cycle
-            m_isrLastCycle = (ESP.getCycleCount() | 1) ^ m_invert;
-            if (m_bitCycles >= (ESP.getCpuFreqMHz() * 1000000UL) / 74880UL)
+            // Init to stop bit level and current tick
+            m_isrLastTick = (micros() | 1) ^ m_invert;
+            if (m_bitTicks >= (1000000UL) / 74880UL)
                 attachInterruptArg(digitalPinToInterrupt(m_rxPin), reinterpret_cast<void (*)(void*)>(rxBitISR), this, CHANGE);
             else
                 attachInterruptArg(digitalPinToInterrupt(m_rxPin), reinterpret_cast<void (*)(void*)>(rxBitSyncISR), this, m_invert ? RISING : FALLING);
@@ -315,9 +315,9 @@ int SoftwareSerial::available() {
 void SoftwareSerial::lazyDelay() {
     // Reenable interrupts while delaying to avoid other tasks piling up
     if (!m_intTxEnabled) { restoreInterrupts(); }
-    const auto expired = ESP.getCycleCount() - m_periodStart;
+    const auto expired = micros() - m_periodStart;
     const int32_t remaining = m_periodDuration - expired;
-    const int32_t ms = remaining > 0 ? remaining / 1000L / static_cast<int32_t>(ESP.getCpuFreqMHz()) : 0;
+    const int32_t ms = remaining > 0 ? remaining / 1000L / static_cast<int32_t>(1) : 0;
     if (ms > 0)
     {
         delay(ms);
@@ -332,9 +332,9 @@ void SoftwareSerial::lazyDelay() {
 }
 
 void IRAM_ATTR SoftwareSerial::preciseDelay() {
-    while ((ESP.getCycleCount() - m_periodStart) < m_periodDuration) {}
+    while ((micros() - m_periodStart) < m_periodDuration) {}
     m_periodDuration = 0;
-    m_periodStart = ESP.getCycleCount();
+    m_periodStart = micros();
 }
 
 void IRAM_ATTR SoftwareSerial::writePeriod(
@@ -409,7 +409,7 @@ size_t IRAM_ATTR SoftwareSerial::write(const uint8_t* buffer, size_t size, Softw
     const uint32_t dataMask = ((1UL << m_dataBits) - 1);
     bool withStopBit = true;
     m_periodDuration = 0;
-    m_periodStart = ESP.getCycleCount();
+    m_periodStart = micros();
     for (size_t cnt = 0; cnt < size; ++cnt) {
         uint8_t byte = pgm_read_byte(buffer + cnt) & dataMask;
         // push LSB start-data-parity-stop bit pattern into uint32_t
@@ -460,10 +460,10 @@ size_t IRAM_ATTR SoftwareSerial::write(const uint8_t* buffer, size_t size, Softw
                 dutyCycle = offCycle = 0;
             }
             if (b) {
-                dutyCycle += m_bitCycles;
+                dutyCycle += m_bitTicks;
             }
             else {
-                offCycle += m_bitCycles;
+                offCycle += m_bitTicks;
             }
         }
         withStopBit = true;
@@ -525,24 +525,24 @@ void SoftwareSerial::rxBits() {
     // Check that there was no new ISR data received in the meantime, inserting an
     // extraneous stop level bit out of sequence breaks rx.
     if (m_rxLastBit < m_pduBits - 1) {
-        const uint32_t detectionCycles = (m_pduBits - 1 - m_rxLastBit) * m_bitCycles;
-        if (!m_isrBuffer->available() && ESP.getCycleCount() - m_isrLastCycle > detectionCycles) {
+        const uint32_t detectionTicks = (m_pduBits - 1 - m_rxLastBit) * m_bitTicks;
+        if (!m_isrBuffer->available() && micros() - m_isrLastTick > detectionTicks) {
             // Produce faux stop bit level, prevents start bit maldetection
-            // cycle's LSB is repurposed for the level bit
-            rxBits(((m_isrLastCycle + detectionCycles) | 1) ^ m_invert);
+            // tick's LSB is repurposed for the level bit
+            rxBits(((m_isrLastTick + detectionTicks) | 1) ^ m_invert);
         }
     }
 }
 
-void SoftwareSerial::rxBits(const uint32_t isrCycle) {
-    const bool level = (m_isrLastCycle & 1) ^ m_invert;
+void SoftwareSerial::rxBits(const uint32_t isrTick) {
+    const bool level = (m_isrLastTick & 1) ^ m_invert;
 
-    // error introduced by edge value in LSB of isrCycle is negligible
-    uint32_t cycles = isrCycle - m_isrLastCycle;
-    m_isrLastCycle = isrCycle;
+    // error introduced by edge value in LSB of isrTick is negligible
+    uint32_t ticks = isrTick - m_isrLastTick;
+    m_isrLastTick = isrTick;
 
-    uint32_t bits = cycles / m_bitCycles;
-    if (cycles % m_bitCycles > (m_bitCycles >> 1)) ++bits;
+    uint32_t bits = ticks / m_bitTicks;
+    if (ticks % m_bitTicks > (m_bitTicks >> 1)) ++bits;
     while (bits > 0) {
         // start bit detection
         if (m_rxLastBit >= (m_pduBits - 1)) {
@@ -603,29 +603,29 @@ void SoftwareSerial::rxBits(const uint32_t isrCycle) {
 }
 
 void IRAM_ATTR SoftwareSerial::rxBitISR(SoftwareSerial* self) {
-    uint32_t curCycle = ESP.getCycleCount();
+    uint32_t curTick = micros();
     bool level = *self->m_rxReg & self->m_rxBitMask;
 
-    // Store level and cycle in the buffer unless we have an overflow
-    // cycle's LSB is repurposed for the level bit
-    if (!self->m_isrBuffer->push((curCycle | 1U) ^ !level)) self->m_isrOverflow.store(true);
+    // Store level and tick in the buffer unless we have an overflow
+    // tick's LSB is repurposed for the level bit
+    if (!self->m_isrBuffer->push((curTick | 1U) ^ !level)) self->m_isrOverflow.store(true);
 }
 
 void IRAM_ATTR SoftwareSerial::rxBitSyncISR(SoftwareSerial* self) {
-    uint32_t start = ESP.getCycleCount();
-    uint32_t wait = self->m_bitCycles - 172U;
+    uint32_t start = micros();
+    uint32_t wait = self->m_bitTicks - 172U;
 
     bool level = self->m_invert;
-    // Store level and cycle in the buffer unless we have an overflow
-    // cycle's LSB is repurposed for the level bit
+    // Store level and tick in the buffer unless we have an overflow
+    // tick's LSB is repurposed for the level bit
     if (!self->m_isrBuffer->push(((start + wait) | 1U) ^ !level)) self->m_isrOverflow.store(true);
 
     for (uint32_t i = 0; i < self->m_pduBits; ++i) {
-        while (ESP.getCycleCount() - start < wait) {};
-        wait += self->m_bitCycles;
+        while (micros() - start < wait) {};
+        wait += self->m_bitTicks;
 
-        // Store level and cycle in the buffer unless we have an overflow
-        // cycle's LSB is repurposed for the level bit
+        // Store level and tick in the buffer unless we have an overflow
+        // tick's LSB is repurposed for the level bit
         if (static_cast<bool>(*self->m_rxReg & self->m_rxBitMask) != level)
         {
             if (!self->m_isrBuffer->push(((start + wait) | 1U) ^ level)) self->m_isrOverflow.store(true);

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -230,7 +230,7 @@ private:
     void setRxGPIOPullUp();
     /* check m_rxValid that calling is safe */
     void rxBits();
-    void rxBits(const uint32_t isrCycle);
+    void rxBits(const uint32_t isrTick);
     static void disableInterrupts();
     static void restoreInterrupts();
 
@@ -262,7 +262,7 @@ private:
     uint8_t m_stopBits;
     bool m_lastReadParity;
     bool m_overflow = false;
-    uint32_t m_bitCycles;
+    uint32_t m_bitTicks;
     uint8_t m_parityInPos;
     uint8_t m_parityOutPos;
     int8_t m_rxLastBit; // 0 thru (m_pduBits - m_stopBits - 1): data/parity bits. -1: start bit. (m_pduBits - 1): stop bit.
@@ -279,9 +279,9 @@ private:
     // the ISR stores the relative bit times in the buffer. The inversion corrected level is used as sign bit (2's complement):
     // 1 = positive including 0, 0 = negative.
     std::unique_ptr<circular_queue<uint32_t, SoftwareSerial*> > m_isrBuffer;
-    const Delegate<void(uint32_t&&), SoftwareSerial*> m_isrBufferForEachDel = { [](SoftwareSerial* self, uint32_t&& isrCycle) { self->rxBits(isrCycle); }, this };
+    const Delegate<void(uint32_t&&), SoftwareSerial*> m_isrBufferForEachDel = { [](SoftwareSerial* self, uint32_t&& isrTick) { self->rxBits(isrTick); }, this };
     std::atomic<bool> m_isrOverflow;
-    uint32_t m_isrLastCycle;
+    uint32_t m_isrLastTick;
     bool m_rxCurParity = false;
     Delegate<void(int available), void*> receiveHandler;
 };

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -237,6 +237,13 @@ private:
     static void rxBitISR(SoftwareSerial* self);
     static void rxBitSyncISR(SoftwareSerial* self);
 
+    static inline uint32_t microsToTicks(uint32_t micros) {
+        return micros << 1;
+    }
+    static inline uint32_t ticksToMicros(uint32_t ticks) {
+        return ticks >> 1;
+    }
+
     // Member variables
     int8_t m_rxPin = -1;
     volatile uint32_t* m_rxReg;


### PR DESCRIPTION
It appears that CPU frequency shifts are corrected for in the timekeeping code for micros() on ESP32 S2 / C3, whereas the straight use of CPU cycles for SoftwareSerial bit timings fails when the CPU clock is scaled for high-performance SDK functions, like webserver loads.
This PR bases the timings on longer on CPU cycles but on microseconds as returned by the micros() functions.

Fixes #255 