### PR TITLE
Move busy-loop wait in lazyDelay() back outside critical section

### DIFF
--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -351,9 +351,9 @@ void SoftwareSerial::lazyDelay() {
     {
         optimistic_yield(10000UL);
     }
+    preciseDelay();
     // Disable interrupts again if applicable
     if (!m_intTxEnabled) { disableInterrupts(); }
-    preciseDelay();
 }
 
 void IRAM_ATTR SoftwareSerial::preciseDelay() {


### PR DESCRIPTION
The refactoring commit e8c10628a32f ("Polymorphism over parameter evaluation.") separated the lazy-delay and precise-delay scenarios into two different functions. In the process of doing so, this commit introduced an (unintended?) change of behavior, by moving the busy-wait loop (encoded in the preciseDelay() call) used inside lazyDelay() INSIDE the critical section (the busy-loop was OUTSIDE the critical section prior to this commit). This change of behavior causes unreliable bit write timing at 9600bps 8N1 when using interrupt disabling for half-duplex (RS485) scenarios. Fix this by moving the busy-loop back OUTSIDE the critical section, thus restoring the previous working behavior.

Fixes: 1906d2fbbd9e9b61f4d88f0acc66ea5d3cbc68b8 ("In timing critical sections, use direct register access for digital read/write. (#231)")
Fixes: e8c10628a32f37e7bc9582acff8aecb8a7074562 ("Polymorphism over parameter evaluation.")