### PR TITLE
Release 7.0.0

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -30,7 +30,6 @@ end	KEYWORD2
 isListening	KEYWORD2
 stopListening	KEYWORD2
 onReceive	KEYWORD2
-perform_work	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EspSoftwareSerial",
-    "version": "6.17.1",
+    "version": "7.0.0",
     "description": "Implementation of the Arduino software serial for ESP8266/ESP32.",
     "keywords": [
         "serial", "io", "softwareserial"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EspSoftwareSerial
-version=6.17.1
+version=7.0.0
 author=Dirk Kaar, Peter Lerup
 maintainer=Dirk Kaar <dok@dok-net.net>
 sentence=Implementation of the Arduino software serial for ESP8266/ESP32.

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -69,10 +69,7 @@ SoftwareSerial::~SoftwareSerial() {
     end();
 }
 
-#if __GNUC__ >= 10
-constexpr
-#endif
-bool SoftwareSerial::isValidGPIOpin(int8_t pin) const {
+constexpr bool SoftwareSerial::isValidGPIOpin(int8_t pin) {
 #if defined(ESP8266)
     return (pin >= 0 && pin <= 16) && !isFlashInterfacePin(pin);
 #elif defined(ESP32)
@@ -80,7 +77,7 @@ bool SoftwareSerial::isValidGPIOpin(int8_t pin) const {
     // Remmove the flash memory pins on related devices, since using these causes memory access issues.
 #ifdef CONFIG_IDF_TARGET_ESP32
     // Datasheet https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf,
-    // Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32/_images/esp32-devkitC-v4-pinout.jpg    
+    // Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32/_images/esp32-devkitC-v4-pinout.jpg
     return (pin == 1) || (pin >= 3 && pin <= 5) ||
         (pin >= 12 && pin <= 15) ||
         (!psramFound() && pin >= 16 && pin <= 17) ||
@@ -91,10 +88,10 @@ bool SoftwareSerial::isValidGPIOpin(int8_t pin) const {
     // Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/_images/esp32-s2_saola1-pinout.jpg
     return (pin >= 1 && pin <= 21) || (pin >= 33 && pin <= 44);
 #elif CONFIG_IDF_TARGET_ESP32C3
-    // Datasheet https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf, 
+    // Datasheet https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf,
     // Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/_images/esp32-c3-devkitm-1-v1-pinout.jpg
     return (pin >= 0 && pin <= 1) || (pin >= 3 && pin <= 7) || (pin >= 18 && pin <= 21);
-#else 
+#else
     return pin >= 0;
 #endif
 #else
@@ -102,10 +99,7 @@ bool SoftwareSerial::isValidGPIOpin(int8_t pin) const {
 #endif
 }
 
-#if __GNUC__ >= 10
-constexpr
-#endif
-bool SoftwareSerial::isValidRxGPIOpin(int8_t pin) const {
+constexpr bool SoftwareSerial::isValidRxGPIOpin(int8_t pin) {
     return isValidGPIOpin(pin)
 #if defined(ESP8266)
         && (pin != 16)
@@ -113,10 +107,7 @@ bool SoftwareSerial::isValidRxGPIOpin(int8_t pin) const {
         ;
 }
 
-#if __GNUC__ >= 10
-constexpr
-#endif
-bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) const {
+constexpr bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) {
     return isValidGPIOpin(pin)
 #if defined(ESP32)
 #ifdef CONFIG_IDF_TARGET_ESP32
@@ -130,10 +121,7 @@ bool SoftwareSerial::isValidTxGPIOpin(int8_t pin) const {
         ;
 }
 
-#if __GNUC__ >= 10
-constexpr
-#endif
-bool SoftwareSerial::hasRxGPIOPullUp(int8_t pin) const {
+constexpr bool SoftwareSerial::hasRxGPIOPullUp(int8_t pin) {
 #if defined(ESP32)
     return !(pin >= 34 && pin <= 39);
 #else

--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -342,7 +342,7 @@ void SoftwareSerial::lazyDelay() {
     if (!m_intTxEnabled) { restoreInterrupts(); }
     const auto expired = microsToTicks(micros()) - m_periodStart;
     const int32_t remaining = m_periodDuration - expired;
-    const int32_t ms = remaining > 0 ? static_cast<int32_t>(ticksToMicros(remaining) / 1000L) : 0;
+    const uint32_t ms = remaining > 0 ? ticksToMicros(remaining) / 1000UL : 0;
     if (ms > 0)
     {
         delay(ms);
@@ -359,11 +359,9 @@ void SoftwareSerial::lazyDelay() {
 
 void IRAM_ATTR SoftwareSerial::preciseDelay() {
     uint32_t ticks;
-    uint32_t expired;
     do {
         ticks = microsToTicks(micros());
-        expired =  ticks - m_periodStart;
-    } while (static_cast<int32_t>(m_periodDuration - expired) > 0);
+    } while ((ticks - m_periodStart) < m_periodDuration);
     m_periodDuration = 0;
     m_periodStart = ticks;
 }

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -224,11 +224,11 @@ private:
     // If offCycle == 0, the level remains unchanged from dutyCycle.
     void writePeriod(
         uint32_t dutyCycle, uint32_t offCycle, bool withStopBit);
-    constexpr bool isValidGPIOpin(int8_t pin) const;
-    constexpr bool isValidRxGPIOpin(int8_t pin) const;
-    constexpr bool isValidTxGPIOpin(int8_t pin) const;
+    static constexpr bool isValidGPIOpin(int8_t pin);
+    static constexpr bool isValidRxGPIOpin(int8_t pin);
+    static constexpr bool isValidTxGPIOpin(int8_t pin);
     // result is only defined for a valid Rx GPIO pin
-    constexpr bool hasRxGPIOPullUp(int8_t pin) const;
+    static constexpr bool hasRxGPIOPullUp(int8_t pin);
     // safely set the pin mode for the Rx GPIO pin
     void setRxGPIOPinMode();
     // safely set the pin mode for the Tx GPIO pin

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -203,12 +203,13 @@ public:
     bool isListening() { return m_rxEnabled; }
     bool stopListening() { enableRx(false); return true; }
 
-    /// Set an event handler for received data.
-    void onReceive(Delegate<void(int available), void*> handler);
-
-    /// Run the internal processing and event engine. Can be iteratively called
-    /// from loop, or otherwise scheduled.
-    void perform_work();
+    /// onReceive sets a callback that will be called in interrupt context
+    /// when data is received.
+    /// More precisely, the callback is triggered when EspSoftwareSerial detects
+    /// a new reception, which may not yet have completed on invocation.
+    /// Reading - never from this interrupt context - should therefore be
+    /// delayed for the duration of one incoming word.
+    void onReceive(Delegate<void(), void*> handler);
 
     using Print::write;
 
@@ -295,7 +296,8 @@ private:
     std::atomic<bool> m_isrOverflow;
     uint32_t m_isrLastTick;
     bool m_rxCurParity = false;
-    Delegate<void(int available), void*> receiveHandler;
+    Delegate<void(), void*> m_rxHandler;
 };
 
 #endif // __SoftwareSerial_h
+


### PR DESCRIPTION
This release contains two changes:
- Fixes #265 , the constexpr compiler errors reported on ESP32
- Drops `perform_work` in favor of HW IRQ-based callback that may be useful for power saving by suspending the task that handles SW serial input.