### PR TITLE
fix: typos

### DIFF
--- a/src/SoftwareSerial.cpp
+++ b/src/SoftwareSerial.cpp
@@ -261,7 +261,7 @@ int UARTBase::available() {
 }
 
 void UARTBase::lazyDelay() {
-    // Reenable interrupts while delaying to avoid other tasks piling up
+    // Re-enable interrupts while delaying to avoid other tasks piling up
     if (!m_intTxEnabled) { restoreInterrupts(); }
     const auto expired = ticks() - m_periodStart;
     const int32_t remaining = m_periodDuration - expired;

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -51,7 +51,7 @@ public:
         return (pin >= 0 && pin <= 16) && !isFlashInterfacePin(pin);
     #elif defined(ESP32)
         // Remove the strapping pins as defined in the datasheets, they affect bootup and other critical operations
-        // Remmove the flash memory pins on related devices, since using these causes memory access issues.
+        // Remove the flash memory pins on related devices, since using these causes memory access issues.
     #ifdef CONFIG_IDF_TARGET_ESP32
         // Datasheet https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf,
         // Pinout    https://docs.espressif.com/projects/esp-idf/en/latest/esp32/_images/esp32-devkitC-v4-pinout.jpg

--- a/src/circular_queue/cancellation_token.h
+++ b/src/circular_queue/cancellation_token.h
@@ -117,7 +117,7 @@ namespace ghostl
         /// cancellation_token_source is cancelled. Never call this more than once
         /// on the same cancellation_token, but get another cancellation token.
         /// </summary>
-        /// <returns>A bool task, that has a value of true if cancellation occured,
+        /// <returns>A bool task, that has a value of true if cancellation occurred,
         /// or false if the cancellation source etc was deleted without cancellation.</returns>
         [[nodiscard]] auto cancellation_request() -> ghostl::task<bool>
         {

--- a/src/circular_queue/circular_queue.h
+++ b/src/circular_queue/circular_queue.h
@@ -89,7 +89,7 @@ public:
     circular_queue& operator=(const circular_queue&) = delete;
 
     /*!
-        @brief  Get the numer of elements the queue can hold at most.
+        @brief  Get the number of elements the queue can hold at most.
     */
     size_t capacity() const
     {


### PR DESCRIPTION
I used the awesome codespell for that:
```console
$ codespell -w -i 3 -S '*.pdf' .
```