### PR TITLE
Change the way the ghostl dependency is included

### DIFF
--- a/library.json
+++ b/library.json
@@ -25,6 +25,6 @@
     ],
     "dependencies":
     {
-        "dok-net/ghostl": "^1.0.0"
+	"ghostl": "https://github.com/dok-net/ghostl.git"
     }
 }


### PR DESCRIPTION
Modified the `dependencies.json` file to use the url to the git repo.
This way the dependency can automatically be downloaded by platformio in my case.
This should probably be tested more.