### PR TITLE
Fix breaking change: missing PlatformIO integration of new dependency package ghostl

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EspSoftwareSerial",
-    "version": "8.2.0",
+    "version": "8.2.1",
     "description": "Implementation of the Arduino software serial for ESP8266/ESP32.",
     "keywords": [
         "serial", "io", "softwareserial"
@@ -25,6 +25,6 @@
     ],
     "dependencies":
     {
-        "dok-net/ghostl": "^1.0.0"
+        "dok-net/ghostl": "https://codeload.github.com/dok-net/ghostl/zip/refs/tags/1.0.1"
     }
 }


### PR DESCRIPTION
The `library.json` references the `dok-net/ghostl` library via a PIO Registry version string, but no such library exists.

Making it just reference the stable 1.0.1 version from github makes it work.

Alternatively register the package (I've actually done that as `maxgerhardt/ghostl @ ^1.0.1`, the [PIO Registry](https://registry.platformio.org/) hopefully picks it up soon) and reference it correctly in the `library.json`. But referencing non-existing packages makes PIO go kaboom.

Test install and proof:
```
>pio pkg install -g -l https://github.com/maxgerhardt/espsoftwareserial.git
Library Manager: Installing git+https://github.com/maxgerhardt/espsoftwareserial.git
git version 2.38.1.windows.1
Cloning into 'C:\Users\Max\.platformio\.cache\tmp\pkg-installing-zn187w8b'...
remote: Enumerating objects: 24, done.
remote: Counting objects: 100% (24/24), done.
remote: Compressing objects: 100% (18/18), done.
remote: Total 24 (delta 1), reused 10 (delta 0), pack-reused 0
Receiving objects: 100% (24/24), 32.20 KiB | 6.44 MiB/s, done.
Resolving deltas: 100% (1/1), done.
Library Manager: EspSoftwareSerial@8.2.1+sha.6d91487 has been installed!
Library Manager: Resolving dependencies...
Library Manager: Installing https://codeload.github.com/dok-net/ghostl/zip/refs/tags/1.0.1
Downloading...
Unpacking  [####################################]  100%
Library Manager: ghostl@1.0.1 has been installed!
```

Fixes #307 